### PR TITLE
Mining using player_id

### DIFF
--- a/Scenes/Player/Melee_Attack.gd
+++ b/Scenes/Player/Melee_Attack.gd
@@ -22,11 +22,4 @@ func _on_Area2D_body_entered(body: Node) -> void:
 		var damage = 150
 		body.take_damage(damage, player_id)
 	elif body.is_in_group("Ores"):
-		if ServerData.mining_data[body.name][sd.ACTIVE] == 1:
-			if ServerData.mining_data[body.name][sd.CURRENT_HITS] == ServerData.mining_data[body.name][sd.HITS_HP] - 1:
-				#node drops item and goes inactive
-				ServerData.mining_data[body.name][sd.ACTIVE] = 0
-				ServerData.mining_data[body.name][sd.CURRENT_HITS] = 0
-			else:
-				ServerData.mining_data[body.name][sd.CURRENT_HITS] += 1
-
+		body.take_damage(1, player_id)

--- a/Scenes/Props/Ore.gd
+++ b/Scenes/Props/Ore.gd
@@ -1,14 +1,46 @@
 extends StaticBody2D
 
-var sd = ServerData
 var respawn_timer_active = false
+var status_dict
+var attacks_per_player = {}
+var time_since_last_attacked = 0
 
-func _physics_process(_delta):
-	if ServerData.mining_data[self.name][sd.ACTIVE] == 0:
+func _ready():
+	# TODO: make this better
+	set_status_dict(ServerData.mining_data[name])
+
+func set_status_dict(dict):
+	status_dict = dict
+
+func _physics_process(delta):
+	if status_dict[ServerData.ACTIVE] == 0:
 		if not respawn_timer_active:
 			respawn_timer_active = true
-			yield(get_tree().create_timer(ServerData.mining_data[self.name][sd.RESPAWN]),"timeout")
+			yield(get_tree().create_timer(status_dict[ServerData.RESPAWN]),"timeout")
 			respawn_timer_active = false
-			ServerData.mining_data[self.name][sd.ACTIVE] = 1
-			
+			status_dict[ServerData.ACTIVE] = 1
+			time_since_last_attacked = 0
+	else:
+		# reset the attack history if node was not interacted with for 10 seconds
+		time_since_last_attacked += delta
+		if time_since_last_attacked > 10:
+			attacks_per_player.clear()
+
+func take_damage(value, player_id):
+	if status_dict == null:
+		# TODO: log an error, shouldn't happen
+		return
+	if status_dict[ServerData.ACTIVE] == 1:
+		time_since_last_attacked = 0
+		if attacks_per_player.has(player_id):
+			attacks_per_player[player_id] += value
+		else:
+			attacks_per_player[player_id] = value
 		
+		if attacks_per_player[player_id] >= status_dict[ServerData.HITS_HP]:
+			#node drops item and goes inactive
+			attacks_per_player.clear()
+			status_dict[ServerData.ACTIVE] = 0
+			status_dict[ServerData.CURRENT_HITS] = 0
+		else:
+			status_dict[ServerData.CURRENT_HITS] += 1


### PR DESCRIPTION
## Description

Whenever an attempt at mining and ore node is performed, player_id of the miner is saved in a dictionary together with total number of attempts by this player.
If the number of hits by a player reaches the ore nodes' HITS_HP property, it is mined.
The dictionary for player storage is reset after 10 seconds of non-interaction or if the node is successfully mined.

## Motivation

Mining node takes 3 hits,
Player A hits mining node two times,
Player b hits mining node 1 time.
Mining node is still active and would require either one more hit from Player A or 2 more hits from player B.

## Testing
![test3](https://user-images.githubusercontent.com/16952886/138531352-0971a980-4fc3-472c-83d4-2597c868214b.gif)


