### PR TITLE
Inventory persistence

### DIFF
--- a/Scenes/Main/GameServer.gd
+++ b/Scenes/Main/GameServer.gd
@@ -102,4 +102,9 @@ func EnemyAttack(enemy_id, attack_type):
 func SendPlayerInventory(inventory_data, session_token):
 	rpc_id(session_token, "ReceivePlayerInventory", inventory_data)
 
-
+# swap two locations in inventory
+remote func swap_items(from, to):
+	var player_id = get_tree().get_rpc_sender_id()
+	Players.get_player(player_id).swap_items(from, to)
+	rpc_id(player_id, "item_swap_ok")
+	

--- a/Scenes/Player/player.gd
+++ b/Scenes/Player/player.gd
@@ -6,6 +6,7 @@ var hitbox : StaticBody2D
 var si = ServerInterface
 
 var stats = {}
+var inventory : Dictionary
 
 
 func initialize(player_id, init_state):
@@ -21,8 +22,9 @@ func update(new_state):
   hitbox.position = new_state[si.PLAYER_POSITION]
 
 func remove():
-  hitbox.get_parent().remove_child(hitbox)
-  hitbox.queue_free()
+	hitbox.get_parent().remove_child(hitbox)
+	hitbox.queue_free()
+	HubConnection.save_inventory(hitbox.id, inventory)
 
 func get_position():
 	return hitbox.position
@@ -37,3 +39,24 @@ func take_damage(value):
 	current_health = max(0, current_health - value)
 	stats["current_health"] = current_health
 	hitbox.display("Current health: " + str(current_health))
+
+func set_inventory(new_inventory):
+	inventory = new_inventory
+	
+func swap_items(from, to):
+	print(inventory)
+	if not from in inventory.keys():
+		# nothing to do, from needs to be an item
+		return
+	if not to in inventory.keys():
+		# only source item exists, just change its slot
+		var item_id = inventory[from]["item_id"]
+		inventory[to] = { "item_id" : item_id}
+		# this slot is no longer occupied, erase it from dictionary
+		inventory.erase(from)
+		return
+	
+	# both items exist, swap them
+	var item = inventory[to]
+	inventory[to] = inventory[from]
+	inventory[from] = item

--- a/Scenes/Singletons/HubConnection.gd
+++ b/Scenes/Singletons/HubConnection.gd
@@ -55,6 +55,8 @@ func SendPlayerTokenToAuthDatabase(player_id, token):
 	rpc_id(1, "ReceivePlayerTokenForDatabase", player_id, token)
 	
 remote func ReceivePlayerInventory(inventory_data, session_token):
+	# Session token == player_id
+	Players.get_player(session_token).set_inventory(inventory_data)
 	gameserver.SendPlayerInventory(inventory_data, session_token)
 
 func GetAllItemsFromDatabase():
@@ -63,3 +65,6 @@ func GetAllItemsFromDatabase():
 remote func ReceiveItemData(all_item_data):
 	print(all_item_data)
 	ItemDatabase.all_item_data = all_item_data
+
+func save_inventory(session_token, new_inventory):
+	rpc_id(1, "update_inventory", session_token, new_inventory)


### PR DESCRIPTION
## Description

This adds a cached version of the player inventory to WorldServer. Client can now swap (move) items in the player's inventory in the cache. When player disconnects the cache is sent to Auth to save in the database.

## Motivation

Allow players to gain and equip items.

## Testing

I'll upload the gifs to the Client PR