### PR TITLE
added playerId to monsters, tagged system, item gets a player tag

### DIFF
--- a/Scenes/Main/GameServer.gd
+++ b/Scenes/Main/GameServer.gd
@@ -68,11 +68,12 @@ remote func ReturnToken(token):
 	var player_id = get_tree().get_rpc_sender_id()
 	player_verification_process.Verify(player_id, token)
 
-func ReturnTokenVerificationResults(player_id, result):
+func ReturnTokenVerificationResults(player_id : int, result : bool):
 	rpc_id(player_id, "ReturnTokenVerificationResults", result, ItemDatabase.all_item_data)
 	if result == true:
 		rpc_id(0, "SpawnNewPlayer", player_id, Vector2(450, 220))
 		rpc_id(player_id, "GetItemsOnGround", get_node("ServerMap").GetItemsOnGround())
+		rpc_id(player_id, "StorePlayerID", player_id)
 
 remote func FetchPlayerStats():
 	var player_id = get_tree().get_rpc_sender_id()
@@ -111,8 +112,8 @@ remote func swap_items(from, to):
 		player.swap_items(from, to)
 	rpc_id(player_id, "item_swap_ok")
 	
-func AddItemDropToClient(item_id, item_name, item_position):
-	rpc_id(0, "AddItemDropToClient", item_id, item_name, item_position)
+func AddItemDropToClient(item_id : int, item_name : String, item_position : Vector2, tagged_by_player : int):
+	rpc_id(0, "AddItemDropToClient", item_id, item_name, item_position,tagged_by_player)
 	
 func RemoveItemDropFromClient(item_name):
 	rpc_id(0, "RemoveItemDropFromClient", item_name)

--- a/Scenes/Maps/ServerMap.gd
+++ b/Scenes/Maps/ServerMap.gd
@@ -35,10 +35,11 @@ func SpawnPlayer(_player_id, _location):
 	pass
 	
 	
-func SpawnItemDrop(drop_position, item_id):
+func SpawnItemDrop(tagged_by_player : int, drop_position : Vector2, item_id : int):
 	var new_item_drop = item_drop.instance()
 	new_item_drop.position = drop_position
 	new_item_drop.item_id = item_id
+	new_item_drop.tagged_by_player = tagged_by_player
 	get_node("YSort/Items").add_child(new_item_drop)
 	
 func GetItemsOnGround() -> Array:

--- a/Scenes/Props/ItemGround.gd
+++ b/Scenes/Props/ItemGround.gd
@@ -2,12 +2,12 @@ extends StaticBody2D
 
 onready var gameserver = get_node("/root/Server")
 var item_id : int
-var player_id : int
+var tagged_by_player : int
 var anyone_pick_up : bool = true
 
 func _ready():
 	name = str(randi () % 10000000+1)
-	gameserver.AddItemDropToClient(item_id, name, position)
+	gameserver.AddItemDropToClient(item_id, name, position, tagged_by_player)
 	print(name)
 
 func _on_RemoveItem_timeout():

--- a/Scenes/Singletons/EnemyData.gd
+++ b/Scenes/Singletons/EnemyData.gd
@@ -2,10 +2,10 @@ extends Node
 
 onready var enemies = {
 	"Slime":{
-		"MaxHealth": 300
+		"MaxHealth": 10
 	},
 	"Mino":{
-		"MaxHealth": 600
+		"MaxHealth": 10
 	}
 }
 

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -13,8 +13,8 @@ script_encryption_key=""
 
 [preset.0.options]
 
-custom_template/debug=""
-custom_template/release=""
+custom_template/debug="/home/rick/Desktop/Ender-Woods/Ender-Woods-Authentication-Server/export_templates/godot_server.x11.opt.debug.64"
+custom_template/release="/home/rick/Desktop/Ender-Woods/Ender-Woods-Authentication-Server/export_templates/godot_server.x11.opt.64"
 binary_format/64_bits=true
 binary_format/embed_pck=false
 texture_format/bptc=false
@@ -48,7 +48,6 @@ texture_format/etc=false
 texture_format/etc2=false
 texture_format/no_bptc_fallbacks=true
 codesign/enable=false
-codesign/identity_type=0
 codesign/identity=""
 codesign/password=""
 codesign/timestamp=true


### PR DESCRIPTION
#IF YOU APPROVE MERGE THIS WITH CLIENT PR.
## Description
Added player-id to **player node** when they login . This allows the player to check their own playerid against playerids attached to items/monsters etc...
Added monster tagged feature: Monsters are tagged for X seconds when hit by a player. A timer starts and if it expires before it is hit by that same player again the player_id is removed from that monster (set to 0). If another player hits the enemy whilst the timer is running, the damage still happens but the player tag remains the same as the first player. 
This player_id tag on the monster can be used to award exp and kill credit but right now it is used to be attached to the item that the monster drops.
The client get rpc from world server with item and player_id of the killer. It then spawns the item into the world, if the item has the same player_id as the **player_node**, then the item appears as normal. If it is not the same (the player isnt the one who killed the monster), that item will appear transparent for X seconds determined by the server (TODO).

TODO: Item pick up
Send how long left on the server timer so client knows when to stop being transparent.


## Motivation

monster tagging is a part of most mmorpgs, and also player_id is handy to have for the future



## Testing

https://user-images.githubusercontent.com/53924507/140520425-983989ae-a5e1-4f22-a89b-5d03508b798c.mp4



