### PR TITLE
Fixed a bug where the same packets were sent twice

### DIFF
--- a/Scenes/Main/GameServer.gd
+++ b/Scenes/Main/GameServer.gd
@@ -187,5 +187,4 @@ func send_all_packets():
 			else:
 				rpc_id(player_id, "handle_uncompressed_input_packets", packet_bundle.buffer)
 			packet_bundle.free()
-			rpc_id(player_id, "handle_input_packets", packets_to_send[player_id])
 	packets_to_send = {}


### PR DESCRIPTION
## Description

Same packets were being sent twice, once serialized and once unserialized.

## Motivation

We dont want packet duplication

## Testing

Running with current version causes two printouts on clients for each packet == double send.
With the fix the second print is no longer visible
