### PR TITLE
Fix segmentation fault

### DIFF
--- a/Scenes/Player/player.gd
+++ b/Scenes/Player/player.gd
@@ -24,8 +24,11 @@ func update(new_state):
   hitbox.position = new_state[si.PLAYER_POSITION]
 
 func remove():
-	hitbox.get_parent().remove_child(hitbox)
-	hitbox.queue_free()
+	if hitbox == null:
+		Logger.warn("Player disconnected before registering")
+	else:
+		hitbox.queue_free()
+		hitbox = null
 	HubConnection.save_inventory(hitbox.id, inventory.slots)
 
 func get_position():


### PR DESCRIPTION
## Description

Fixed segfault when players disconnect before registering their hitbox with the world.


## Testing

Tested it in unit test locally. Cannot be a part of the commit because I dont know how to test networks in unit tests yet.