### PR TITLE
Fixed enemies getting stuck in EVADE

### DIFF
--- a/Scenes/Enemies/Enemy.gd
+++ b/Scenes/Enemies/Enemy.gd
@@ -142,9 +142,11 @@ func process_state(delta):
 				elif not is_attacking: # wait until the swing animation is finished to move
 					velocity = (destination - position).normalized() * pars.get(EnemyParameters.CHASE_SPEED) * delta
 		State.EVADE:
-			velocity = (spawn_point - position).normalized() * pars.get(EnemyParameters.WANDER_SPEED) * delta
-			if (position - spawn_point).length() < 2:
+			if (position - spawn_point).length_squared() < 4:
 				enter_state(State.IDLE)
+			else:
+				velocity = (spawn_point - position).normalized() * pars.get(EnemyParameters.WANDER_SPEED) * delta
+				velocity = velocity.clamped((spawn_point - position).length())
 
 	if tagged_by_player != 0:
 		tagged_timer.advance(delta)

--- a/tests/unit/test_enemy.gd
+++ b/tests/unit/test_enemy.gd
@@ -1,0 +1,21 @@
+extends "res://addons/gut/test.gd"
+var mino_scene = load("res://Scenes/Enemies/Mino.tscn")
+
+# this tests that enemies dont overshoot their spawn point when returning from
+# evade to idle
+func test_enemy_no_idle_overshoot():
+	var mino : Enemy = mino_scene.instance()
+	mino.spawn_point = Vector2(0.0, 0.0)
+	mino.position = Vector2(2.01, 0.0)
+	
+	# mino tries to return to spawn
+	mino.enter_state(Enemy.State.EVADE)
+	
+	mino._physics_process(0.125)
+	mino.position += mino.velocity # simulate physics movement
+	assert_eq(mino.state, Enemy.State.EVADE)
+	mino._physics_process(0.125)
+	
+	# mino is very close to spawn so it should just enter idle state
+	assert_eq(mino.state, Enemy.State.IDLE)
+	mino.queue_free()


### PR DESCRIPTION


## Description

Enemies sometimes got stuck when returning from EVADE back to spawn. This was caused by them constantly overshooting the spawn point.
Added a testcase for this specific case.

## Motivation

Fix invulnerable enemies

## Testing

I've added a testcase since its hard to reproduce.