### PR TITLE
Get/set current_health and experience from/to Nakama

### DIFF
--- a/Scenes/Main/GameServer.gd
+++ b/Scenes/Main/GameServer.gd
@@ -83,13 +83,13 @@ remote func return_token(token):
 	player_verification_process.verify(player_id, token)
 
 func return_token_verification_results(player_id : int, result : bool):
-	rpc_id(player_id, "return_token_verification_results", result)
+	var player : Player = Players.get_player(player_id)
+	rpc_id(player_id, "return_token_verification_results", result, player.experience, player.current_health)
 	if result == true:
 		rpc_id(player_id, "get_items_on_ground", get_node("ServerMap").get_items_on_ground())
 		
 		Players.initialize_player(player_id, get_node("ServerMap/YSort/Players"))
 		
-		var player : Player = Players.get_player(player_id)
 		# start the process of getting the items from database
 		var nakama_request : NakamaRequest = NakamaRequest.new()
 		add_child(nakama_request)

--- a/Scenes/Player/player.gd
+++ b/Scenes/Player/player.gd
@@ -28,11 +28,12 @@ func set_experience(_experience):
 func set_current_health(_current_health):
 	# TODO: make this part of a "Stat" node, just set the value in the stat
 	# node of player and add a getter also
-	if current_health == -1:
+	if _current_health == -1:
 		# TODO: set _current_health to max_health, this happens when current 
 		# health is uninitialized: player just started the game or some reset
 		# conditions in the future
-		pass
+		# To test out gamedata saving
+		_current_health = 100
 	current_health = _current_health
 	# TODO: Check if player died. Perform on death actions
 

--- a/Scenes/Player/player.gd
+++ b/Scenes/Player/player.gd
@@ -8,6 +8,8 @@ var stats : Dictionary = {}
 var inventory : Inventory = Inventory.new()
 var username : String
 var user_id : String
+var experience : int setget set_experience
+var current_health : float setget set_current_health
 
 var hitbox_scene = preload("res://Scenes/Player/PlayerHitbox.tscn")
 
@@ -16,6 +18,23 @@ func initialize(player_id):
 	hitbox.id = player_id
 	hitbox.position = Vector2(250, 250) # Spawn point
 	hitbox.display("Current health: " + str(stats["current_health"]))
+	
+func set_experience(_experience):
+	# TODO: make this part of a "Stat" node, just set the value in the stat
+	# node of player and add a getter also
+	experience = _experience
+	# TODO: Call some function to recalcualte stats
+	
+func set_current_health(_current_health):
+	# TODO: make this part of a "Stat" node, just set the value in the stat
+	# node of player and add a getter also
+	if current_health == -1:
+		# TODO: set _current_health to max_health, this happens when current 
+		# health is uninitialized: player just started the game or some reset
+		# conditions in the future
+		pass
+	current_health = _current_health
+	# TODO: Check if player died. Perform on death actions
 
 func register(world):
 	world.add_child(hitbox)

--- a/Scenes/Singletons/NakamaConnection.gd
+++ b/Scenes/Singletons/NakamaConnection.gd
@@ -65,6 +65,8 @@ func _handle_verify_token_response(result, response_code, headers, body, request
 	request.queue_free()
 	var player : Player = Players.get_player(player_id)
 	if player:
+		player.experience = data["gamedata"]["experience"]
+		player.current_health = data["gamedata"]["current_health"]
 		player.username = data["username"]
 		player.user_id = data["user_id"]
 


### PR DESCRIPTION
## Description

current_health and experience is loaded from Nakama when verifying user account.
Added setter methods in player.gd - to be updated when stat node is added.

## Testing

I've created a new account, the metadata was correctly created on the Nakama instance and loaded into WorldServer

![image](https://user-images.githubusercontent.com/16952886/144194856-5f5a760e-d679-48d0-ad14-09fb3dd437e4.png)
