### PR TITLE
finished with refactor / quest start

### DIFF
--- a/Scenes/Main/GameServer.gd
+++ b/Scenes/Main/GameServer.gd
@@ -26,8 +26,8 @@ var si = ServerInterface
 func _ready():
 	OS.set_window_position(Vector2(0,0))
 	Logger.info("%s: Ready function called" % filename)
-	NakamaConnection.get_item_database()
-	NakamaConnection.get_recipe_database()
+	NakamaConnection.get_items_database()
+	NakamaConnection.get_crafting_recipes_database()
 	start_server()
 	Logger.info("%s: finished Client>World Server function" % filename)
 	
@@ -93,8 +93,8 @@ func return_token_verification_results(player_id : int, result : bool):
 		# start the process of getting the items from database
 		var nakama_request : NakamaRequest = NakamaRequest.new()
 		add_child(nakama_request)
-		nakama_request.connect("request_completed", self, "_handle_get_inventory", [player_id])
-		nakama_request.request("get_inventory", { "user_id": player.user_id })
+		nakama_request.connect("request_completed", self, "_handle_get_player_inventory", [player_id])
+		nakama_request.request("get_player_inventory", { "user_id": player.user_id })
 		
 		# Spawn all enemies for the player that just connected
 		for packet in get_node("ServerMap").get_enemy_state_packets():
@@ -277,7 +277,7 @@ remote func stop_smelter():
 	send_packet(player_id, si.create_smelter_stopped_packet())
 
 
-func _handle_get_inventory(input_data, output_data, request : NakamaRequest, player_id):
+func _handle_get_player_inventory(input_data, output_data, request : NakamaRequest, player_id):
 	request.queue_free()
 	var player : Player = Players.get_player(player_id)
 	if player:

--- a/Scenes/Singletons/NakamaConnection.gd
+++ b/Scenes/Singletons/NakamaConnection.gd
@@ -8,24 +8,85 @@ var ip_port = "127.0.0.1:7350"
 # to prevent cheating by calling our APIs
 var http_key = "defaulthttpkey"
 
-func get_item_database():
+# Item Database
+func get_items_database():
 	var request = HTTPRequest.new()
 	add_child(request)
-	request.connect("request_completed", self, "_handle_item_db_received", [request])
-	var error = request.request("http://" + ip_port + "/v2/rpc/get_items?http_key=" + http_key)
+	request.connect("request_completed", self, "_handle_items_database_received", [request])
+	var error = request.request("http://" + ip_port + "/v2/rpc/get_items_database?http_key=" + http_key)
 	if error != OK:
 		push_error("An error occurred in the HTTP request.")
 		assert(false)
 
-func get_recipe_database():
+func _handle_items_database_received(result, response_code, headers, body, request : HTTPRequest):
+	var response = parse_json(body.get_string_from_utf8())	
+	var data = JSON.parse(response["payload"]).result
+	request.queue_free()
+	assert(data["success"] == true)
+	Logger.info("Received item data from Nakama server")
+	
+	ItemDatabase.all_item_data = data["result"]
+	Utils.convert_keys_to_int(ItemDatabase.all_item_data)
+
+# Crafting Recipes Database
+func get_crafting_recipes_database():
 	var request = HTTPRequest.new()
 	add_child(request)
-	request.connect("request_completed", self, "_handle_recipe_db_received", [request])
-	var error = request.request("http://" + ip_port + "/v2/rpc/get_recipes?http_key=" + http_key)
+	request.connect("request_completed", self, "_handle_crafting_recipes_database_received", [request])
+	var error = request.request("http://" + ip_port + "/v2/rpc/get_crafting_recipes_database?http_key=" + http_key)
 	if error != OK:
 		push_error("An error occurred in the HTTP request.")
 		assert(false)
+
+func _handle_crafting_recipes_database_received(result, response_code, headers, body, request : HTTPRequest):
+	var response = parse_json(body.get_string_from_utf8())	
+	request.queue_free()
+	var data = JSON.parse(response["payload"]).result
+	assert(data["success"] == true)
+	Logger.info("Received recipes data from Nakama server")
 	
+	ItemDatabase.all_recipe_data = data["result"]
+	Utils.convert_keys_to_int(ItemDatabase.all_recipe_data)
+
+# Item Modifier Database
+func get_item_modifiers_database():
+	var request = HTTPRequest.new()
+	add_child(request)
+	request.connect("request_completed", self, "_handle_item_modifiers_database_received", [request])
+	var error = request.request("http://" + ip_port + "/v2/rpc/get_item_modifiers_database?http_key=" + http_key)
+	if error != OK:
+		push_error("An error occurred in the HTTP request.")
+		assert(false)
+		
+func _handle_item_modifiers_database_received(result, response_code, headers, body, request : HTTPRequest):
+	var response = parse_json(body.get_string_from_utf8())	
+	var data = JSON.parse(response["payload"]).result
+	request.queue_free()
+	assert(data["success"] == true)
+	Logger.info("Received item data from Nakama server")
+	
+	# TODO use the item modifiers data received
+
+# Quests Database
+func get_quests_database():
+	var request = HTTPRequest.new()
+	add_child(request)
+	request.connect("request_completed", self, "_handle_quests_database_received", [request])
+	var error = request.request("http://" + ip_port + "/v2/rpc/get_quests_database?http_key=" + http_key)
+	if error != OK:
+		push_error("An error occurred in the HTTP request.")
+		assert(false)	
+
+func _handle_quests_database_received(result, response_code, headers, body, request : HTTPRequest):
+	var response = parse_json(body.get_string_from_utf8())	
+	var data = JSON.parse(response["payload"]).result
+	request.queue_free()
+	assert(data["success"] == true)
+	Logger.info("Received item data from Nakama server")
+	
+	# TODO use the quest data received
+	
+# Verify Token	
 func verify_token(player_id, token):
 	var request = HTTPRequest.new()
 	add_child(request)
@@ -36,27 +97,6 @@ func verify_token(player_id, token):
 	if error != OK:
 		push_error("An error occurred in the HTTP request.")
 		emit_signal("token_verified", false, player_id, token)
-
-func _handle_recipe_db_received(result, response_code, headers, body, request : HTTPRequest):
-	var response = parse_json(body.get_string_from_utf8())	
-	request.queue_free()
-	var data = JSON.parse(response["payload"]).result
-	assert(data["success"] == true)
-	Logger.info("Received recipes data from Nakama server")
-	
-	ItemDatabase.all_recipe_data = data["result"]
-	Utils.convert_keys_to_int(ItemDatabase.all_recipe_data)
-
-func _handle_item_db_received(result, response_code, headers, body, request : HTTPRequest):
-	var response = parse_json(body.get_string_from_utf8())	
-	var data = JSON.parse(response["payload"]).result
-	request.queue_free()
-	assert(data["success"] == true)
-	Logger.info("Received item data from Nakama server")
-	
-	ItemDatabase.all_item_data = data["result"]
-	Utils.convert_keys_to_int(ItemDatabase.all_item_data)
-
 
 func _handle_verify_token_response(result, response_code, headers, body, request : HTTPRequest, player_id : int, token : String):
 	Logger.info("Verify token response result: %s, response_code: %s, headers: %s, body: %s, token: %s" %


### PR DESCRIPTION
# Nakama / World / Client all have a PR. All must be merged together as this is extremely breaking!

## Description

Changes for Nakama / World / Client
Removed some of the files, renamed some rpcs, added quests
removed the meta data and added it to player stats
Organised RPCs via their type, Database > Database. Player rpcs (quest. inventory, stats) > Player_rpcs. Itll be obvious when you take a look.
Changed default IP to local.
Added code to receive quest database and also item modifiers to world.
probably some other minor things.

## Motivation

Add the ability to start quest development.
Refactor and clean up some code to make it more readable
Renaming to keep code consistent and also make it more readable eg: game_data > player_stats. game_data at a glance could mean anything.


## Testing

create multiple accounts, login to multiple accounts. Move items around, test all endpoints, set player account data like inventory, player stats and quest states. Everything works just as it did before  with the addition of questing being added.

